### PR TITLE
Laravel 5.4 incompatible due to use of share method on package's service provider.

### DIFF
--- a/src/PromocodesServiceProvider.php
+++ b/src/PromocodesServiceProvider.php
@@ -33,10 +33,8 @@ class PromocodesServiceProvider extends ServiceProvider
             __DIR__.'/config/promocodes.php', 'promocodes'
         );
 
-        $this->app['promocodes'] = $this->app->share(
-            function () {
-                return new Promocodes();
-            }
-        );
+        $this->app->singleton('promocodes', function ($app) {
+            return new Promocodes();
+        });
     }
 }


### PR DESCRIPTION
Share method for registering singletons has been deprecated in Laravel 5.4, use the singleton method instead.