### PR TITLE
Fix exception names

### DIFF
--- a/src/Exceptions/AlreadyUsedException.php
+++ b/src/Exceptions/AlreadyUsedException.php
@@ -4,7 +4,7 @@ namespace Gabievi\Promocodes\Exceptions;
 
 use Exception;
 
-class AlreadyUsedExceprion extends Exception
+class AlreadyUsedException extends Exception
 {
     /**
      * @var string

--- a/src/Exceptions/InvalidPromocodeException.php
+++ b/src/Exceptions/InvalidPromocodeException.php
@@ -4,7 +4,7 @@ namespace Gabievi\Promocodes\Exceptions;
 
 use Exception;
 
-class InvalidPromocodeExceprion extends Exception
+class InvalidPromocodeException extends Exception
 {
     /**
      * @var string

--- a/src/Exceptions/UnauthenticatedException.php
+++ b/src/Exceptions/UnauthenticatedException.php
@@ -4,7 +4,7 @@ namespace Gabievi\Promocodes\Exceptions;
 
 use Exception;
 
-class UnauthenticatedExceprion extends Exception
+class UnauthenticatedException extends Exception
 {
     /**
      * @var string

--- a/src/Promocodes.php
+++ b/src/Promocodes.php
@@ -163,7 +163,7 @@ class Promocodes
 
                 return $promocode->load('users');
             }
-        } catch(InvalidPromocodeException $exception) {
+        } catch (InvalidPromocodeException $exception) {
             //
         }
 

--- a/src/Promocodes.php
+++ b/src/Promocodes.php
@@ -4,9 +4,9 @@ namespace Gabievi\Promocodes;
 
 use Carbon\Carbon;
 use Gabievi\Promocodes\Models\Promocode;
-use Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion;
-use Gabievi\Promocodes\Exceptions\UnauthenticatedExceprion;
-use Gabievi\Promocodes\Exceptions\InvalidPromocodeExceprion;
+use Gabievi\Promocodes\Exceptions\AlreadyUsedException;
+use Gabievi\Promocodes\Exceptions\UnauthenticatedException;
+use Gabievi\Promocodes\Exceptions\InvalidPromocodeException;
 
 class Promocodes
 {
@@ -120,14 +120,14 @@ class Promocodes
      * @param string $code
      *
      * @return bool|\Gabievi\Promocodes\Model\Promocode
-     * @throws \Gabievi\Promocodes\Exceptions\InvalidPromocodeExceprion
+     * @throws \Gabievi\Promocodes\Exceptions\InvalidPromocodeException
      */
     public function check($code)
     {
         $promocode = Promocode::byCode($code)->first();
 
         if ($promocode === null) {
-            throw new InvalidPromocodeExceprion;
+            throw new InvalidPromocodeException;
         }
 
         if ($promocode->isExpired() || ($promocode->isDisposable() && $promocode->users()->exists())) {
@@ -143,18 +143,18 @@ class Promocodes
      * @param string $code
      *
      * @return bool|\Gabievi\Promocodes\Model\Promocode
-     * @throws \Gabievi\Promocodes\Exceptions\UnauthenticatedExceprion|\Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion
+     * @throws \Gabievi\Promocodes\Exceptions\UnauthenticatedException|\Gabievi\Promocodes\Exceptions\AlreadyUsedException
      */
     public function apply($code)
     {
         if (!auth()->check()) {
-            throw new UnauthenticatedExceprion;
+            throw new UnauthenticatedException;
         }
 
         try {
             if ($promocode = $this->check($code)) {
                 if ($this->isSecondUsageAttempt($promocode)) {
-                    throw new AlreadyUsedExceprion;
+                    throw new AlreadyUsedException;
                 }
 
                 $promocode->users()->attach(auth()->user()->id, [
@@ -163,7 +163,7 @@ class Promocodes
 
                 return $promocode->load('users');
             }
-        } catch(InvalidPromocodeExceprion $exception) {
+        } catch(InvalidPromocodeException $exception) {
             //
         }
 
@@ -176,7 +176,7 @@ class Promocodes
      * @param string $code
      *
      * @return bool|\Gabievi\Promocodes\Model\Promocode
-     * @throws \Gabievi\Promocodes\Exceptions\UnauthenticatedExceprion|\Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion
+     * @throws \Gabievi\Promocodes\Exceptions\UnauthenticatedException|\Gabievi\Promocodes\Exceptions\AlreadyUsedException
      */
     public function redeem($code)
     {
@@ -188,14 +188,14 @@ class Promocodes
      *
      * @param string $code
      * @return bool
-     * @throws \Gabievi\Promocodes\Exceptions\InvalidPromocodeExceprion
+     * @throws \Gabievi\Promocodes\Exceptions\InvalidPromocodeException
      */
     public function disable($code)
     {
         $promocode = Promocode::byCode($code)->first();
 
         if ($promocode === null) {
-            throw new InvalidPromocodeExceprion;
+            throw new InvalidPromocodeException;
         }
 
         $promocode->expires_at = Carbon::now();

--- a/src/Traits/Rewardable.php
+++ b/src/Traits/Rewardable.php
@@ -5,8 +5,8 @@ namespace Gabievi\Promocodes\Traits;
 use Carbon\Carbon;
 use Gabievi\Promocodes\Models\Promocode;
 use Gabievi\Promocodes\Facades\Promocodes;
-use Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion;
-use Gabievi\Promocodes\Exceptions\InvalidPromocodeExceprion;
+use Gabievi\Promocodes\Exceptions\AlreadyUsedException;
+use Gabievi\Promocodes\Exceptions\InvalidPromocodeException;
 
 trait Rewardable
 {
@@ -28,14 +28,14 @@ trait Rewardable
      * @param null|\Closure $callback
      *
      * @return null|\Gabievi\Promocodes\Model\Promocode
-     * @throws \Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion
+     * @throws \Gabievi\Promocodes\Exceptions\AlreadyUsedException
      */
     public function applyCode($code, $callback = null)
     {
         try {
             if ($promocode = Promocodes::check($code)) {
                 if ($promocode->users()->wherePivot('user_id', $this->id)->exists()) {
-                    throw new AlreadyUsedExceprion;
+                    throw new AlreadyUsedException;
                 }
 
                 $promocode->users()->attach($this->id, [
@@ -50,7 +50,7 @@ trait Rewardable
 
                 return $promocode;
             }
-        } catch (InvalidPromocodeExceprion $exception) {
+        } catch (InvalidPromocodeException $exception) {
             //
         }
 
@@ -68,7 +68,7 @@ trait Rewardable
      * @param null|\Closure $callback
      *
      * @return null|\Gabievi\Promocodes\Model\Promocode
-     * @throws \Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion
+     * @throws \Gabievi\Promocodes\Exceptions\AlreadyUsedException
      */
     public function redeemCode($code, $callback = null)
     {

--- a/tests/ApplyPromocodeToUserTest.php
+++ b/tests/ApplyPromocodeToUserTest.php
@@ -5,15 +5,15 @@ namespace Gabievi\Promocodes\Test;
 use Promocodes;
 use Gabievi\Promocodes\Models\Promocode;
 use Gabievi\Promocodes\Test\Models\User;
-use Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion;
-use Gabievi\Promocodes\Exceptions\UnauthenticatedExceprion;
+use Gabievi\Promocodes\Exceptions\AlreadyUsedException;
+use Gabievi\Promocodes\Exceptions\UnauthenticatedException;
 
 class ApplyPromocodeToUserTest extends TestCase
 {
     /** @test */
     public function it_throws_exception_if_user_is_not_authenticated()
     {
-        $this->expectException(UnauthenticatedExceprion::class);
+        $this->expectException(UnauthenticatedException::class);
 
         $promocodes = Promocodes::create();
         $promocode = $promocodes->first();
@@ -37,7 +37,7 @@ class ApplyPromocodeToUserTest extends TestCase
     /** @test */
     public function it_throws_exception_if_user_tries_to_apply_code_twice()
     {
-        $this->expectException(AlreadyUsedExceprion::class);
+        $this->expectException(AlreadyUsedException::class);
 
         $user = User::find(1);
         $this->actingAs($user);

--- a/tests/CheckPromocodeValidationTest.php
+++ b/tests/CheckPromocodeValidationTest.php
@@ -5,14 +5,14 @@ namespace Gabievi\Promocodes\Test;
 use Promocodes;
 use Gabievi\Promocodes\Models\Promocode;
 use Gabievi\Promocodes\Test\Models\User;
-use Gabievi\Promocodes\Exceptions\InvalidPromocodeExceprion;
+use Gabievi\Promocodes\Exceptions\InvalidPromocodeException;
 
 class CheckPromocodeValidationTest extends TestCase
 {
     /** @test */
     public function it_throws_exception_if_there_is_not_such_promocode()
     {
-        $this->expectException(InvalidPromocodeExceprion::class);
+        $this->expectException(InvalidPromocodeException::class);
 
         Promocodes::check('INVALID-CODE');
     }

--- a/tests/DisablePromocodeTest.php
+++ b/tests/DisablePromocodeTest.php
@@ -4,14 +4,14 @@ namespace Gabievi\Promocodes\Test;
 
 use Promocodes;
 use Gabievi\Promocodes\Models\Promocode;
-use Gabievi\Promocodes\Exceptions\InvalidPromocodeExceprion;
+use Gabievi\Promocodes\Exceptions\InvalidPromocodeException;
 
 class DisablePromocodeTest extends TestCase
 {
     /** @test */
     public function it_thows_exception_if_promocode_is_invalid()
     {
-        $this->expectException(InvalidPromocodeExceprion::class);
+        $this->expectException(InvalidPromocodeException::class);
 
         Promocodes::disable('INVALID-CODE');
     }

--- a/tests/RewardableTraitTest.php
+++ b/tests/RewardableTraitTest.php
@@ -5,7 +5,7 @@ namespace Gabievi\Promocodes\Test;
 use Promocodes;
 use Gabievi\Promocodes\Models\Promocode;
 use Gabievi\Promocodes\Test\Models\User;
-use Gabievi\Promocodes\Exceptions\AlreadyUsedExceprion;
+use Gabievi\Promocodes\Exceptions\AlreadyUsedException;
 
 class RewardableTraitTest extends TestCase
 {
@@ -40,7 +40,7 @@ class RewardableTraitTest extends TestCase
     /** @test */
     public function it_throws_exception_if_user_already_applied_to_code()
     {
-        $this->expectException(AlreadyUsedExceprion::class);
+        $this->expectException(AlreadyUsedException::class);
 
         $promocodes = Promocodes::create();
         $promocode = $promocodes->first();


### PR DESCRIPTION
All exception names had a typo. This PR fixes it.
As it's a breaking change, this should go into a 2.0 version.