### PR TITLE
Fix 'promocode_user.user_user_id' column not found

### DIFF
--- a/src/Models/Promocode.php
+++ b/src/Models/Promocode.php
@@ -57,7 +57,7 @@ class Promocode extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(config('promocodes.user_model'), config('promocodes.relation_table'))
+        return $this->belongsToMany(config('promocodes.user_model'), config('promocodes.relation_table'), 'user_id', 'user_id')
             ->withPivot('used_at');
     }
 


### PR DESCRIPTION
When I tried to use 'redeem' or 'apply' method. It gave an exception that 'promocode_user.user_user_id' column not found. So, defining the column names for foreign keys fixed and it worked. Please merge it so it doesn't break package users' code when they update their dependencies.