### PR TITLE
Rename file ServiceProvider.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# laravel-promocodes
+# laravel-promocodes 1
 
 [![Packagist](https://img.shields.io/packagist/v/zgabievi/promocodes.svg)](https://packagist.org/packages/zgabievi/promocodes)
 [![Packagist](https://img.shields.io/packagist/dt/zgabievi/promocodes.svg)](https://packagist.org/packages/zgabievi/promocodes)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# laravel-promocodes 1
+# laravel-promocodes
 
 [![Packagist](https://img.shields.io/packagist/v/zgabievi/promocodes.svg)](https://packagist.org/packages/zgabievi/promocodes)
 [![Packagist](https://img.shields.io/packagist/dt/zgabievi/promocodes.svg)](https://packagist.org/packages/zgabievi/promocodes)

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Gabievi\\Promocodes\\ServiceProvider"
+        "Gabievi\\Promocodes\\PromocodesServiceProvider"
       ],
       "aliases": {
         "Promocodes": "Gabievi\\Promocodes\\Facades\\Promocodes"

--- a/src/PromocodesServiceProvider.php
+++ b/src/PromocodesServiceProvider.php
@@ -4,7 +4,7 @@ namespace Gabievi\Promocodes;
 
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
-class ServiceProvider extends BaseServiceProvider
+class PromocodesServiceProvider extends BaseServiceProvider
 {
     /**
      * Bootstrap the application services.

--- a/src/PromocodesServiceProvider.php
+++ b/src/PromocodesServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Gabievi\Promocodes;
 
-use Illuminate\Support\ServiceProvider as BaseServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
-class PromocodesServiceProvider extends BaseServiceProvider
+class PromocodesServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application services.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,7 +25,7 @@ abstract class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
-            \Gabievi\Promocodes\ServiceProvider::class
+            \Gabievi\Promocodes\PromocodesServiceProvider::class
         ];
     }
 


### PR DESCRIPTION
Fix Error:
In ProviderRepository.php line 208:
  Class 'Gabievi\Promocodes\PromocodesServiceProvider' not found

Rename ServiceProvider.php to PromocodesServiceProvider.php, because all services in config/app.php called like {Name}ServiceProvider.php