### PR TITLE
Make assert eqauls strict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: php
 sudo: required
 
 php:
-- 7.1
 - 7.2
+- 7.3
+- 7.4
 
 before_script:
 - travis_retry composer self-update

--- a/tests/CreatePromocodesToDatabaseTest.php
+++ b/tests/CreatePromocodesToDatabaseTest.php
@@ -41,7 +41,7 @@ class CreatePromocodesToDatabaseTest extends TestCase
         $promocode = $promocodes->first();
 
         $this->assertCount(1, $promocodes);
-        $this->assertEquals(10, $promocode['reward']);
+        $this->assertSame(10, $promocode['reward']);
         $this->assertDatabaseHas('promocodes', [
             'code' => $promocode['code'],
             'reward' => $promocode['reward']
@@ -64,7 +64,7 @@ class CreatePromocodesToDatabaseTest extends TestCase
             'code' => $promocode['code'],
             'data' => json_encode($data),
         ]);
-        $this->assertEquals('bar', $promocode['data']['foo']);
+        $this->assertSame('bar', $promocode['data']['foo']);
     }
 
     /** @test */


### PR DESCRIPTION
# Changed log

- It seems that the package require `php-7.2` version at least, and it should remove `php-7.1` version and add `php-7.2`, `php-7.3` and `php-7.4` versions on Travis CI build.
- Using the assertSame to make assert equals strict.